### PR TITLE
chore: respect SOURCE_DATE_EPOCH for build timestamp

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,6 @@
 use anyhow::Result;
+use chrono::TimeZone;
+use std::env;
 use std::fs;
 use std::process::Command;
 use vergen_gitcl::{Emitter, GitclBuilder};
@@ -21,9 +23,14 @@ fn main() -> Result<()> {
     }
 
     // Add build timestamp
+    let now = match env::var("SOURCE_DATE_EPOCH") {
+        Ok(val) => { chrono::Utc.timestamp_opt(val.parse::<i64>().unwrap(), 0).unwrap() }
+        Err(_) => chrono::Utc::now(),
+    };
+
     println!(
         "cargo:rustc-env=BUILD_TIMESTAMP={}",
-        chrono::Utc::now().format("%Y-%m-%d %H:%M:%S UTC")
+        now.format("%Y-%m-%d %H:%M:%S UTC")
     );
 
     // Get truehd library version using cargo metadata


### PR DESCRIPTION
[Several distribution build tools set the SOURCE_DATE_EPOCH environment variable which can be used a reproducible build timestamp][1]. Use it (when set) to ensure that the build is reproducible.

[1]: https://reproducible-builds.org/docs/source-date-epoch/