### PR TITLE
fix: YAML formatting with regex - only add leading spaces before key names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- [fix: YAML formatting with regex - only add leading spaces before key names](https://github.com/truehdd/truehdd/pull/18)
+
 ## [0.4.0] - 2025-08-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,6 +89,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitstream-io"
 version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,6 +332,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "fancy-regex"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "998b056554fbe42e03ae0e152895cd1a7e1002aec800fdc6635d20270260c46f"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -538,9 +564,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -550,9 +576,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -716,6 +742,7 @@ dependencies = [
  "chrono",
  "clap",
  "env_logger",
+ "fancy-regex",
  "indicatif",
  "indicatif-log-bridge",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ truehd = { version = "0.4.0", path = "truehd" }
 anyhow = "1.0.99"
 clap = { version = "4.5.45", features = ["derive"] }
 env_logger = "0.11.8"
+fancy-regex = "0.16.2"
 indicatif = "0.18.0"
 indicatif-log-bridge = "0.2.3"
 log = "0.4.27"

--- a/src/damf.rs
+++ b/src/damf.rs
@@ -1,3 +1,4 @@
+use fancy_regex::Regex;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt::Display;
 use std::path::Path;
@@ -666,9 +667,20 @@ where
 }
 
 /// Helper function for common YAML string formatting
-fn format_yaml_string(mut yaml_str: String) -> String {
+fn format_yaml_string(yaml_str: String) -> String {
+    let mut yaml_str = yaml_str;
+
+    // Remove single quotes
     yaml_str.retain(|c| c != '\'');
-    yaml_str.replace("  ", "    ").replace("- ", "  - ")
+
+    // 2 leading spaces; before the property name ending in `:`
+    let leading_spaces_regex = Regex::new(r"[ ]{2}(?=.+:)").unwrap();
+
+    // A hyphen followed by a space; before the property name ending in `:`
+    let leading_hyphen_regex = Regex::new(r"-[ ](?=.+:)").unwrap();
+    
+    let filtered_str = leading_spaces_regex.replace_all(&yaml_str, "    ");
+    leading_hyphen_regex.replace_all(&filtered_str, "  - ").to_string()
 }
 
 #[test]
@@ -678,8 +690,8 @@ fn roundtrip() {
 presentations:
   - type: home
     simplified: false
-    metadata: NaturesFury.atmos.metadata
-    audio: NaturesFury.atmos.audio
+    metadata: Natures  -  Fury.atmos.metadata
+    audio: Natures  -  Fury.atmos.audio
     offset: 3598.0
     ffoa: 3600.0
     fps: 24
@@ -760,8 +772,8 @@ fn damf() {
 presentations:
   - type: home
     simplified: false
-    metadata: test.atmos.metadata
-    audio: test.atmos.audio
+    metadata: test  -  output.atmos.metadata
+    audio: test  -  output.atmos.audio
     offset: 0.0
     fps: 24
     scBedConfiguration: [3]
@@ -810,7 +822,7 @@ presentations:
     );
 
     let oamd = ObjectAudioMetadataPayload::read(TEST_DATA_TRIM).unwrap();
-    let data = Data::with_oamd_payload(&oamd, Path::new("test"));
+    let data = Data::with_oamd_payload(&oamd, Path::new("test  -  output"));
     let yaml_str = serde_yaml_ng::to_string(&data).unwrap();
 
     assert_eq!(test_str, format_yaml_string(yaml_str));


### PR DESCRIPTION
Fixes #17.

- Adds the `fancy-regex` crate that supports regex with look-around expressions.
- I assume there's an unavoidable issue with single-quotes, so I left that alone.
- Refactors the other formatting replacements using regex with look-ahead, to add leading spaces only _before_ key names in the YAML (before non-whitespace characters preceding a `:`).
- Leaves the unit tests as written, but changes the test fixtures to include filenames with double spaces and space-hyphen, to test these changes alongside the rest of the output.