### PR TITLE
fix(cli): keep bed channels in the Atmos channel count without --bed-conform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Decoding Atmos without `--bed-conform` wrote an audio file header that understated the channel count by the number of bed channels, while the PCM payload still carried every channel. An LFE-only bed with 11 objects produced a CAF declaring 11 channels for 12-channel interleaved data, so the sample count no longer divided evenly and Dolby Atmos tooling rejected the resulting master. This affected 0.5.0 and 0.5.1
+
 ## [0.5.1] - 2026-08-01
 
 ### Fixed

--- a/src/cli/decode/handler.rs
+++ b/src/cli/decode/handler.rs
@@ -91,7 +91,14 @@ impl ChannelInfo {
     fn for_atmos(original_count: usize, bed_indices: &[usize], bed_conform: bool) -> Self {
         let bed_channels = bed_indices.len();
         let object_channels = original_count.saturating_sub(bed_indices.len());
-        let total_channels = if bed_conform { TARGET_BED_CHANNELS } else { 0 } + object_channels;
+        // Without bed conformance the bed channels are written through untouched,
+        // so they must stay part of the total. Only conformance replaces them with
+        // a full 7.1.2 bed.
+        let total_channels = if bed_conform {
+            TARGET_BED_CHANNELS
+        } else {
+            bed_channels
+        } + object_channels;
 
         Self {
             total_channels,
@@ -924,4 +931,53 @@ fn create_path_with_suffix(base_path: &Path, suffix: &str) -> PathBuf {
     );
     path.set_file_name(new_name);
     path
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Without bed conformance every decoded channel is written through as-is,
+    /// so the reported channel count has to match the PCM layout exactly.
+    /// Getting this wrong produces a CAF/W64 header that disagrees with its own
+    /// payload, which downstream Atmos tooling rejects.
+    #[test]
+    fn atmos_without_bed_conform_keeps_bed_channels() {
+        // 12 decoded channels: an LFE-only bed plus 11 objects.
+        let info = ChannelInfo::for_atmos(12, &[3], false);
+
+        assert_eq!(info.total_channels, 12);
+        assert_eq!(info.bed_channels, 1);
+        assert_eq!(info.object_channels, 11);
+        assert!(!info.is_bed_conformed);
+    }
+
+    #[test]
+    fn atmos_with_bed_conform_expands_to_full_bed() {
+        let info = ChannelInfo::for_atmos(12, &[3], true);
+
+        assert_eq!(info.total_channels, TARGET_BED_CHANNELS + 11);
+        assert_eq!(info.bed_channels, 1);
+        assert_eq!(info.object_channels, 11);
+        assert!(info.is_bed_conformed);
+    }
+
+    #[test]
+    fn atmos_without_bed_conform_matches_decoded_count_for_full_bed() {
+        // 7.1.2 bed plus 6 objects, no conformance needed.
+        let bed: Vec<usize> = (0..10).collect();
+        let info = ChannelInfo::for_atmos(16, &bed, false);
+
+        assert_eq!(info.total_channels, 16);
+        assert_eq!(info.bed_channels, 10);
+        assert_eq!(info.object_channels, 6);
+    }
+
+    #[test]
+    fn atmos_without_bed_indices_reports_all_channels_as_objects() {
+        let info = ChannelInfo::for_atmos(12, EMPTY_BED_INDICES, false);
+
+        assert_eq!(info.total_channels, 12);
+        assert_eq!(info.object_channels, 12);
+    }
 }


### PR DESCRIPTION
### Summary

Decoding Atmos **without** `--bed-conform` writes an audio file whose header understates the channel count by exactly the number of bed channels, while the PCM payload still contains every channel. The resulting Dolby Atmos master is malformed and is rejected by Dolby tooling — Dolby Media Encoder refuses to open it.

This is a regression in 0.5.0/0.5.1. 0.4.0 is unaffected.

### The defect

`src/cli/decode/handler.rs`:

```rust
let total_channels = if bed_conform { TARGET_BED_CHANNELS } else { 0 } + object_channels;
```

When `bed_conform` is `false`, the bed channels drop out of the total. But that path writes the decoded frames through untouched in `write_buffered_samples`, so the payload still carries `bed_channels + object_channels` channels. The header and the data disagree.

`fa89684` also started populating `bed_indices` unconditionally ("needed for channel descriptions"), which is what makes the subtraction reachable without the flag — previously the slice was empty here and the bug was masked.

For comparison, 0.4.0:

```rust
let effective_channel_count = if ctx.bed_conform && self.has_atmos {
    ChannelCountCalculator::calculate_conformed_channel_count(channel_count, bed_indices)
} else {
    channel_count      // full decoded count
};
```

### Observed impact

A commercial TrueHD Atmos track with an LFE-only bed and 11 objects (12 decoded channels):

| | 0.4.0 | 0.5.1 |
|---|---|---|
| `mChannelsPerFrame` | 12 | **11** |
| `mBytesPerPacket` | 36 | **33** |
| payload | identical | identical |

The payloads are byte-identical across both versions (verified over all 11,119,789,440 bytes) — only the header differs. And the header is not merely cosmetic:

- 11,119,789,440 / 36 = 308,883,040 frames ✔
- 11,119,789,440 / 33 = 336,963,316.36… ✘

The declared frame size does not divide the payload, so there is no valid interpretation of the file. It also contradicts the `.atmos` presentation written alongside it, which correctly lists 1 bed channel (LFE, ID 3) plus objects 10–20.

truehdd's own log line for that file already disagrees with the header it writes:

```
Creating audio file: shelter.atmos.audio (1 bed channel + 11 objects)
```

1 + 11 = 12, but the header says 11.

Patching just those two header fields back to 36/12 makes the 0.5.1 output byte-identical to the working 0.4.0 output, which confirms the payload was always correct and the header is the sole defect.

### The fix

Use the actual bed channel count when no conformance is applied; conformance is the only case that replaces the bed with a full 7.1.2 layout.

```rust
let total_channels = if bed_conform {
    TARGET_BED_CHANNELS
} else {
    bed_channels
} + object_channels;
```

### Tests

Four unit tests covering `ChannelInfo::for_atmos`: partial bed without conformance (the regression case), with conformance, a full 7.1.2 bed without conformance, and the empty-bed-indices path. `cargo test` 18 passed / 0 failed, `cargo clippy --all-targets` clean, `cargo fmt` applied.

Note that anyone who decoded Atmos with 0.5.0 or 0.5.1 has unusable masters on disk, so this may be worth a patch release.
